### PR TITLE
fix: update frontend port from 5173 to 3000 and expose vite to network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ frontend-logs: ## Tail frontend dev server logs
 	$(COMPOSE_CMD) logs -f frontend
 
 frontend-open: ## Open the frontend in your default browser
-	@ $(POETRY) run python -c "import webbrowser; webbrowser.open('http://localhost:5173')"
+	@ $(POETRY) run python -c "import webbrowser; webbrowser.open('http://localhost:3000')"
 
 frontend-build: ## Run production build inside container
 	$(COMPOSE_CMD) run --rm frontend npm run build

--- a/README.md
+++ b/README.md
@@ -11,19 +11,27 @@ On the supply planning side, the challenge is about optimization under constrain
 
 ## Getting Started
 
+Only [Docker Desktop](https://www.docker.com/products/docker-desktop/) is required to run the full stack.
+
 ```bash
 git clone <repo>
 cd <repo>
-streamlit run scripts/app.py # locally run the staffing dashboard
-make install        # installs dependencies & pre-commit hooks
-make lint           # sanity-check tooling
-make test           # run the sample unit tests
-make pipeline-run   # execute the demo training pipeline
+make backend-up     # start FastAPI backend (trains ML model on startup)
+make frontend-up    # start React dashboard
 ```
 
-Poetry 1.8+ is required. If Poetry is not already installed, follow the [official instructions](https://python-poetry.org/docs/#installation).
+Then open:
+- **Dashboard:** http://localhost:3000
+- **API docs:** http://localhost:8000/docs
 
-To run Streamlit locally, you need to install Streamlit by opening your terminal or command prompt and running: `pip install streamlit`.
+```bash
+make install        # installs dependencies & pre-commit hooks (requires Poetry 1.8+)
+make lint           # sanity-check tooling
+make test           # run the sample unit tests
+make pipeline-run   # execute the demo training pipeline (no Docker)
+```
+
+Poetry 1.8+ is required for local development. If Poetry is not already installed, follow the [official instructions](https://python-poetry.org/docs/#installation).
 
 ## Repository Layout
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       dockerfile: DockerFile
       target: dev
     ports:
-      - "5173:5173"
+      - "3000:3000"
     volumes:
       - ./src/main_module/visualization:/app
       - frontend_node_modules:/app/node_modules

--- a/src/main_module/api/main.py
+++ b/src/main_module/api/main.py
@@ -53,7 +53,7 @@ app = FastAPI(title="Workforce Optimization API")
 # Without this, the browser blocks all requests from a different port (CORS error).
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=["http://localhost:3000", "http://localhost:5173"],
     allow_methods=["GET"],
     allow_headers=["*"],
 )

--- a/src/main_module/visualization/README.md
+++ b/src/main_module/visualization/README.md
@@ -2,7 +2,7 @@
 
 React dashboard for the Workforce Optimization project. Built with Vite + React 19 + Tailwind 4 + shadcn/ui.
 
-Runs at **`localhost:5173`** with hot reload.
+Runs at **`localhost:3000`** with hot reload.
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ From the **project root**:
 
 ```bash
 make frontend-up    # build image + start dev server
-make frontend-open  # open localhost:5173 in browser
+make frontend-open  # open localhost:3000 in browser
 make frontend-logs  # tail Vite output / errors
 make frontend-down  # stop the container
 ```

--- a/src/main_module/visualization/vite.config.ts
+++ b/src/main_module/visualization/vite.config.ts
@@ -55,6 +55,7 @@
     },
     server: {
       port: 3000,
+      host: true,
       open: true,
     },
   });


### PR DESCRIPTION
- Set vite server host: true so Vite binds to 0.0.0.0 inside Docker
- Update docker-compose port mapping from 5173:5173 to 3000:3000
- Add localhost:3000 to FastAPI CORS allowed origins
- Update Makefile frontend-open to use port 3000
- Update visualization README and root README to reflect new port
- Replace outdated Streamlit instructions in root README with Docker setup